### PR TITLE
Allow not having any devices in sysfs for Android/Linux

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1373,6 +1373,7 @@ static int sysfs_get_device_list(struct libusb_context *ctx)
 	DIR *devices = opendir(SYSFS_DEVICE_PATH);
 	struct dirent *entry;
 	int r = LIBUSB_ERROR_IO;
+	int num_failed = 0;
 
 	if (!devices) {
 		usbi_err(ctx, "opendir devices failed errno=%d", errno);
@@ -1385,12 +1386,16 @@ static int sysfs_get_device_list(struct libusb_context *ctx)
 			continue;
 
 		if (sysfs_scan_device(ctx, entry->d_name)) {
+			num_failed++;
 			usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
 			continue;
 		}
-
 		r = 0;
 	}
+
+	/* Clear error status if no devices failed to enumerate */
+	if (num_failed == 0)
+		r = 0;
 
 	closedir(devices);
 	return r;


### PR DESCRIPTION
Previously, if no USB devices are connected, the initial scan produces an error, causing libusb_init to fail. This will now cleanly handle when no devices are found when using sysfs.
