### PR TITLE
Add support of non Hotplug devices

### DIFF
--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2795,6 +2795,7 @@ static clockid_t op_get_timerfd_clockid(void)
 }
 #endif
 
+#ifdef __ANDROID__
 static int op_get_device_list(struct libusb_context * ctx,
 	struct discovered_devs **discdevs)
 {
@@ -2855,6 +2856,7 @@ close_out:
 	closedir(devices);
 	return r;
 }
+#endif
 
 const struct usbi_os_backend linux_usbfs_backend = {
 	.name = "Linux usbfs",

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -613,6 +613,8 @@ static void op_exit(void)
 
 static int linux_start_event_monitor(void)
 {
+	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
+		return LIBUSB_SUCCESS;
 #if defined(USE_UDEV)
 	return linux_udev_start_event_monitor();
 #else
@@ -622,6 +624,8 @@ static int linux_start_event_monitor(void)
 
 static int linux_stop_event_monitor(void)
 {
+	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
+		return LIBUSB_SUCCESS;
 #if defined(USE_UDEV)
 	return linux_udev_stop_event_monitor();
 #else
@@ -632,6 +636,8 @@ static int linux_stop_event_monitor(void)
 static int linux_scan_devices(struct libusb_context *ctx)
 {
 	int ret;
+	if (!libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
+		return LIBUSB_SUCCESS;
 
 	usbi_mutex_static_lock(&linux_hotplug_lock);
 
@@ -2789,12 +2795,77 @@ static clockid_t op_get_timerfd_clockid(void)
 }
 #endif
 
+static int op_get_device_list(struct libusb_context * ctx,
+	struct discovered_devs **discdevs)
+{
+	struct discovered_devs *ddd;
+	DIR *devices = opendir(SYSFS_DEVICE_PATH);
+	struct dirent *entry;
+	int r = LIBUSB_SUCCESS;
+	int num_failed = 0;
+	uint8_t busnum, devaddr;
+	unsigned long session_id;
+	struct libusb_device *dev;
+
+	if (!devices) {
+		usbi_err(ctx, "opendir devices failed errno=%d", errno);
+		return r;
+	}
+
+	while ((entry = readdir(devices))) {
+		if ((!isdigit(entry->d_name[0]) && strncmp(entry->d_name, "usb", 3))
+				|| strchr(entry->d_name, ':'))
+			continue;
+
+		r = linux_get_device_address (ctx, 0, &busnum, &devaddr, NULL, entry->d_name);
+		if (LIBUSB_SUCCESS != r) {
+			num_failed++;
+			usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
+			continue;
+		}
+		session_id = busnum << 8 | devaddr;
+		usbi_dbg("busnum %d devaddr %d session_id %ld", busnum, devaddr,
+			 session_id);
+		dev = usbi_get_device_by_session_id(ctx, session_id);
+		if (dev == NULL) {
+			dev = usbi_alloc_device(ctx, session_id);
+			if (!dev) {
+				r = LIBUSB_ERROR_NO_MEM;
+				goto close_out;
+			}
+			r = initialize_device(dev, busnum, devaddr, entry->d_name);
+			if (r < 0)
+				goto out;
+			r = usbi_sanitize_device(dev);
+			if (r < 0)
+				goto out;
+
+		}
+		ddd = discovered_devs_append(*discdevs, dev);
+		if (ddd == NULL)
+			goto out;
+		libusb_unref_device(dev);
+		*discdevs = ddd;
+	}
+	closedir(devices);
+	return r;
+out:
+	libusb_unref_device(dev);
+close_out:
+	closedir(devices);
+	return r;
+}
+
 const struct usbi_os_backend linux_usbfs_backend = {
 	.name = "Linux usbfs",
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER|USBI_CAP_HAS_POLLABLE_DEVICE_FD,
 	.init = op_init,
 	.exit = op_exit,
+#ifdef __ANDROID__
+	.get_device_list = op_get_device_list,
+#else
 	.get_device_list = NULL,
+#endif
 	.hotplug_poll = op_hotplug_poll,
 	.get_device_descriptor = op_get_device_descriptor,
 	.get_active_config_descriptor = op_get_active_config_descriptor,


### PR DESCRIPTION
- Galaxy S6 forbids Netlink access
- libudev also uses Netlink, so useless
- Remove HotPlug service for Android devices
- Add get_device_list for non-HotPlug devices
