### PR TITLE
Support Android N

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2082,7 +2082,11 @@ int API_EXPORTED libusb_has_capability(uint32_t capability)
 	case LIBUSB_CAP_HAS_CAPABILITY:
 		return 1;
 	case LIBUSB_CAP_HAS_HOTPLUG:
+#ifdef __ANDROID__
+		return 0;
+#else
 		return !(usbi_backend->get_device_list);
+#endif
 	case LIBUSB_CAP_HAS_HID_ACCESS:
 		return (usbi_backend->caps & USBI_CAP_HAS_HID_ACCESS);
 	case LIBUSB_CAP_SUPPORTS_DETACH_KERNEL_DRIVER:

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1329,6 +1329,27 @@ libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle)
 }
 
 /** \ingroup dev
+ * Get the underlying device for a dev_node.
+ * UseCase: Android
+ * \param ctx the context to operate on, or NULL for the default context
+ * \param dev_node device path
+ * \param descriptors the raw USB descriptors for the device
+ * \param descriptors_size the size of the descriptors array
+ * \returns the underlying device
+ */
+DEFAULT_VISIBILITY
+libusb_device * LIBUSB_CALL libusb_get_device2(libusb_context *ctx, const char *dev_node,
+	const char* descriptors, size_t descriptors_size)
+{
+	if (usbi_backend->get_device2 == NULL) {
+		/* Not supported on this platform */
+		return NULL;
+	}
+
+	return usbi_backend->get_device2(ctx, dev_node, descriptors, descriptors_size);
+}
+
+/** \ingroup dev
  * Determine the bConfigurationValue of the currently active configuration.
  *
  * You could formulate your own control request to obtain this information,
@@ -2125,7 +2146,6 @@ int usbi_gettimeofday(struct timeval *tp, void *tzp)
 static void usbi_log_str(struct libusb_context *ctx,
 	enum libusb_log_level level, const char * str)
 {
-#if defined(USE_SYSTEM_LOGGING_FACILITY)
 #if defined(OS_WINDOWS) || defined(OS_WINCE)
 	/* Windows CE only supports the Unicode version of OutputDebugString. */
 	WCHAR wbuf[USBI_MAX_LOG_LEN];
@@ -2153,9 +2173,6 @@ static void usbi_log_str(struct libusb_context *ctx,
 #warning System logging is not supported on this platform. Logging to stderr will be used instead.
 	fputs(str, stderr);
 #endif
-#else
-	fputs(str, stderr);
-#endif /* USE_SYSTEM_LOGGING_FACILITY */
 	UNUSED(ctx);
 	UNUSED(level);
 }

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1141,6 +1141,84 @@ int API_EXPORTED libusb_open(libusb_device *dev,
 }
 
 /** \ingroup dev
+ * Open a device with a file descriptor and obtain a device handle.
+ * A handle allows you to perform I/O on the device in question.
+ *
+ * UseCase: Android, after permission granted from Android Device Manager.
+ * The fd can be obtained by calling UsbDeviceConnection.getFileDescriptor().
+ *
+ * Internally, this function adds a reference to the device and makes it
+ * available to you through libusb_get_device(). This reference is removed
+ * during libusb_close().
+ *
+ * This is a non-blocking function; no requests are sent over the bus.
+ *
+ * \param dev the device to open
+ * \param fd the file descriptor for the device
+ * \param handle output location for the returned device handle pointer. Only
+ * populated when the return code is 0.
+ * \returns 0 on success
+ * \returns LIBUSB_ERROR_NO_MEM on memory allocation failure
+ * \returns LIBUSB_ERROR_ACCESS if the user has insufficient permissions
+ * \returns LIBUSB_ERROR_NO_DEVICE if the device has been disconnected
+ * \returns another LIBUSB_ERROR code on other failure
+ */
+int API_EXPORTED libusb_open2(libusb_device *dev, int fd,
+	libusb_device_handle **handle)
+{
+	if (usbi_backend->open2 == NULL) {
+		return LIBUSB_ERROR_NOT_SUPPORTED;
+	}
+
+	struct libusb_context *ctx = DEVICE_CTX(dev);
+	struct libusb_device_handle *_handle;
+	size_t priv_size = usbi_backend->device_handle_priv_size;
+	int r;
+	usbi_dbg("open %d.%d", dev->bus_number, dev->device_address);
+
+	_handle = malloc(sizeof(*_handle) + priv_size);
+	if (!_handle)
+		return LIBUSB_ERROR_NO_MEM;
+
+	r = usbi_mutex_init(&_handle->lock, NULL);
+	if (r) {
+		free(_handle);
+		return LIBUSB_ERROR_OTHER;
+	}
+
+	_handle->dev = libusb_ref_device(dev);
+	_handle->auto_detach_kernel_driver = 0;
+	_handle->claimed_interfaces = 0;
+	memset(&_handle->os_priv, 0, priv_size);
+
+	r = usbi_backend->open2(_handle, fd);
+	if (r < 0) {
+		usbi_dbg("open2 %d.%d returns %d", dev->bus_number, dev->device_address, r);
+		libusb_unref_device(dev);
+		usbi_mutex_destroy(&_handle->lock);
+		free(_handle);
+		return r;
+	}
+
+	usbi_mutex_lock(&ctx->open_devs_lock);
+	list_add(&_handle->list, &ctx->open_devs);
+	usbi_mutex_unlock(&ctx->open_devs_lock);
+	*handle = _handle;
+
+	if (usbi_backend->caps & USBI_CAP_HAS_POLLABLE_DEVICE_FD) {
+		/* At this point, we want to interrupt any existing event handlers so
+		 * that they realise the addition of the new device's poll fd. One
+		 * example when this is desirable is if the user is running a separate
+		 * dedicated libusb events handling thread, which is running with a long
+		 * or infinite timeout. We want to interrupt that iteration of the loop,
+		 * so that it picks up the new fd, and then continues. */
+		usbi_fd_notification(ctx);
+	}
+
+	return 0;
+}
+
+/** \ingroup dev
  * Convenience function for finding a device with a particular
  * <tt>idVendor</tt>/<tt>idProduct</tt> combination. This function is intended
  * for those scenarios where you are using libusb to knock up a quick test

--- a/libusb/core.c
+++ b/libusb/core.c
@@ -2228,6 +2228,7 @@ int usbi_gettimeofday(struct timeval *tp, void *tzp)
 static void usbi_log_str(struct libusb_context *ctx,
 	enum libusb_log_level level, const char * str)
 {
+#if defined(USE_SYSTEM_LOGGING_FACILITY)
 #if defined(OS_WINDOWS) || defined(OS_WINCE)
 	/* Windows CE only supports the Unicode version of OutputDebugString. */
 	WCHAR wbuf[USBI_MAX_LOG_LEN];
@@ -2255,6 +2256,9 @@ static void usbi_log_str(struct libusb_context *ctx,
 #warning System logging is not supported on this platform. Logging to stderr will be used instead.
 	fputs(str, stderr);
 #endif
+#else
+	fputs(str, stderr);
+#endif /* USE_SYSTEM_LOGGING_FACILITY */
 	UNUSED(ctx);
 	UNUSED(level);
 }

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1373,6 +1373,8 @@ int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **handle);
 void LIBUSB_CALL libusb_close(libusb_device_handle *dev_handle);
 libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle);
+libusb_device * LIBUSB_CALL libusb_get_device2(libusb_context *ctx, const char *dev_node,
+	const char* descriptors, size_t descriptors_len);
 
 int LIBUSB_CALL libusb_set_configuration(libusb_device_handle *dev,
 	int configuration);

--- a/libusb/libusb.h
+++ b/libusb/libusb.h
@@ -1371,6 +1371,7 @@ int LIBUSB_CALL libusb_get_max_iso_packet_size(libusb_device *dev,
 	unsigned char endpoint);
 
 int LIBUSB_CALL libusb_open(libusb_device *dev, libusb_device_handle **handle);
+int LIBUSB_CALL libusb_open2(libusb_device *dev, int fd, libusb_device_handle **handle);
 void LIBUSB_CALL libusb_close(libusb_device_handle *dev_handle);
 libusb_device * LIBUSB_CALL libusb_get_device(libusb_device_handle *dev_handle);
 libusb_device * LIBUSB_CALL libusb_get_device2(libusb_context *ctx, const char *dev_node,

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -648,6 +648,8 @@ struct usbi_os_backend {
 	 */
 	int (*open)(struct libusb_device_handle *handle);
 
+	int (*open2)(struct libusb_device_handle *handle, int fd);
+
 	/* Close a device such that the handle cannot be used again. Your backend
 	 * should destroy any resources that were allocated in the open path.
 	 * This may also be a good place to call usbi_remove_pollfd() to inform

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -617,6 +617,10 @@ struct usbi_os_backend {
 	 */
 	void (*hotplug_poll)(void);
 
+	struct libusb_device* (*get_device2)(struct libusb_context *ctx, const char *dev_node,
+		const char* descriptors, size_t descriptors_len);
+
+
 	/* Open a device for I/O and other USB operations. The device handle
 	 * is preallocated for you, you can retrieve the device in question
 	 * through handle->dev.

--- a/libusb/libusbi.h
+++ b/libusb/libusbi.h
@@ -620,7 +620,6 @@ struct usbi_os_backend {
 	struct libusb_device* (*get_device2)(struct libusb_context *ctx, const char *dev_node,
 		const char* descriptors, size_t descriptors_len);
 
-
 	/* Open a device for I/O and other USB operations. The device handle
 	 * is preallocated for you, you can retrieve the device in question
 	 * through handle->dev.

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2796,67 +2796,6 @@ static clockid_t op_get_timerfd_clockid(void)
 #endif
 
 #ifdef __ANDROID__
-static int op_get_device_list(struct libusb_context * ctx,
-	struct discovered_devs **discdevs)
-{
-	struct discovered_devs *ddd;
-	DIR *devices = opendir(SYSFS_DEVICE_PATH);
-	struct dirent *entry;
-	int r = LIBUSB_SUCCESS;
-	int num_failed = 0;
-	uint8_t busnum, devaddr;
-	unsigned long session_id;
-	struct libusb_device *dev;
-
-	if (!devices) {
-		usbi_err(ctx, "opendir devices failed errno=%d", errno);
-		return r;
-	}
-
-	while ((entry = readdir(devices))) {
-		if ((!isdigit(entry->d_name[0]) && strncmp(entry->d_name, "usb", 3))
-				|| strchr(entry->d_name, ':'))
-			continue;
-
-		r = linux_get_device_address (ctx, 0, &busnum, &devaddr, NULL, entry->d_name);
-		if (LIBUSB_SUCCESS != r) {
-			num_failed++;
-			usbi_dbg("failed to enumerate dir entry %s", entry->d_name);
-			continue;
-		}
-		session_id = busnum << 8 | devaddr;
-		usbi_dbg("busnum %d devaddr %d session_id %ld", busnum, devaddr,
-			 session_id);
-		dev = usbi_get_device_by_session_id(ctx, session_id);
-		if (dev == NULL) {
-			dev = usbi_alloc_device(ctx, session_id);
-			if (!dev) {
-				r = LIBUSB_ERROR_NO_MEM;
-				goto close_out;
-			}
-			r = initialize_device(dev, busnum, devaddr, entry->d_name);
-			if (r < 0)
-				goto out;
-			r = usbi_sanitize_device(dev);
-			if (r < 0)
-				goto out;
-
-		}
-		ddd = discovered_devs_append(*discdevs, dev);
-		if (ddd == NULL)
-			goto out;
-		libusb_unref_device(dev);
-		*discdevs = ddd;
-	}
-	closedir(devices);
-	return r;
-out:
-	libusb_unref_device(dev);
-close_out:
-	closedir(devices);
-	return r;
-}
-
 struct libusb_device* op_get_device2(struct libusb_context *ctx, const char *dev_node,
 	const char* descriptors, size_t descriptors_size)
 {
@@ -2950,11 +2889,7 @@ const struct usbi_os_backend linux_usbfs_backend = {
 	.caps = USBI_CAP_HAS_HID_ACCESS|USBI_CAP_SUPPORTS_DETACH_KERNEL_DRIVER|USBI_CAP_HAS_POLLABLE_DEVICE_FD,
 	.init = op_init,
 	.exit = op_exit,
-#ifdef __ANDROID__
-	.get_device_list = op_get_device_list,
-#else
 	.get_device_list = NULL,
-#endif
 	.hotplug_poll = op_hotplug_poll,
 	.get_device_descriptor = op_get_device_descriptor,
 	.get_active_config_descriptor = op_get_active_config_descriptor,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1463,6 +1463,13 @@ static int op_open(struct libusb_device_handle *handle)
 	return usbi_add_pollfd(HANDLE_CTX(handle), hpriv->fd, POLLOUT);
 }
 
+static int op_open2(struct libusb_device_handle *handle, int fd)
+{
+	struct linux_device_handle_priv *hpriv = _device_handle_priv(handle);
+	hpriv->fd = fd;
+	return usbi_add_pollfd(HANDLE_CTX(handle), hpriv->fd, POLLOUT);
+}
+
 static void op_close(struct libusb_device_handle *dev_handle)
 {
 	int fd = _device_handle_priv(dev_handle)->fd;
@@ -2902,6 +2909,11 @@ const struct usbi_os_backend linux_usbfs_backend = {
 	.get_device2 = NULL,
 #endif
 	.open = op_open,
+#ifdef __ANDROID__
+	.open2 = op_open2,
+#else
+	.open2 = NULL,
+#endif
 	.close = op_close,
 	.get_configuration = op_get_configuration,
 	.set_configuration = op_set_configuration,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -1463,12 +1463,14 @@ static int op_open(struct libusb_device_handle *handle)
 	return usbi_add_pollfd(HANDLE_CTX(handle), hpriv->fd, POLLOUT);
 }
 
+#ifdef __ANDROID__
 static int op_open2(struct libusb_device_handle *handle, int fd)
 {
 	struct linux_device_handle_priv *hpriv = _device_handle_priv(handle);
 	hpriv->fd = fd;
 	return usbi_add_pollfd(HANDLE_CTX(handle), hpriv->fd, POLLOUT);
 }
+#endif
 
 static void op_close(struct libusb_device_handle *dev_handle)
 {

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2820,7 +2820,7 @@ struct libusb_device* op_get_device2(struct libusb_context *ctx, const char *dev
 		return NULL;
 	}
 
-	/* retrive the device */
+	/* retrieve the device */
 	session_id = busnum << 8 | devaddr;
 	usbi_dbg("busnum %d devaddr %d session_id %ld", busnum, devaddr,
 		session_id);

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2856,6 +2856,93 @@ close_out:
 	closedir(devices);
 	return r;
 }
+
+struct libusb_device* op_get_device2(struct libusb_context *ctx, const char *dev_node,
+	const char* descriptors, size_t descriptors_size)
+{
+	uint8_t busnum, devaddr;
+	unsigned int session_id;
+	if (linux_get_device_address(ctx, 0, &busnum, &devaddr,
+		dev_node, NULL) != LIBUSB_SUCCESS) {
+		usbi_dbg("failed to get device address (%s)", dev_node);
+		return NULL;
+	}
+
+	/* make sure device is enumerated */
+	if (linux_enumerate_device2(ctx, busnum, devaddr, descriptors, descriptors_size) < 0) {
+		usbi_dbg("failed to enumerate (%s)", dev_node);
+		return NULL;
+	}
+
+	/* retrive the device */
+	session_id = busnum << 8 | devaddr;
+	usbi_dbg("busnum %d devaddr %d session_id %ld", busnum, devaddr,
+		session_id);
+
+	return usbi_get_device_by_session_id(ctx, session_id);
+}
+
+static int initialize_device2(struct libusb_device *dev, uint8_t busnum,
+	uint8_t devaddr, const char* descriptors, size_t descriptors_size)
+{
+	struct linux_device_priv *priv = _device_priv(dev);
+
+	dev->bus_number = busnum;
+	dev->device_address = devaddr;
+
+	priv->descriptors = usbi_reallocf(priv->descriptors,
+					  descriptors_size);
+	if (!priv->descriptors) {
+		return LIBUSB_ERROR_NO_MEM;
+	}
+	memcpy(priv->descriptors, descriptors, descriptors_size);
+	priv->descriptors_len = descriptors_size;
+	return LIBUSB_SUCCESS;
+}
+
+int linux_enumerate_device2(struct libusb_context *ctx, uint8_t busnum, uint8_t devaddr,
+	const char* descriptors, size_t descriptors_size)
+{
+	unsigned long session_id;
+	struct libusb_device *dev;
+	int r = 0;
+
+	/* FIXME: session ID is not guaranteed unique as addresses can wrap and
+	 * will be reused. instead we should add a simple sysfs attribute with
+	 * a session ID. */
+	session_id = busnum << 8 | devaddr;
+	usbi_dbg("busnum %d devaddr %d session_id %ld", busnum, devaddr,
+		session_id);
+
+	dev = usbi_get_device_by_session_id(ctx, session_id);
+	if (dev) {
+		/* device already exists in the context */
+		usbi_dbg("session_id %ld already exists", session_id);
+		libusb_unref_device(dev);
+		return LIBUSB_SUCCESS;
+	}
+
+	usbi_dbg("allocating new device for %d/%d (session %ld)",
+		 busnum, devaddr, session_id);
+	dev = usbi_alloc_device(ctx, session_id);
+	if (!dev)
+		return LIBUSB_ERROR_NO_MEM;
+
+	r = initialize_device2(dev, busnum, devaddr, descriptors, descriptors_size);
+	if (r < 0)
+		goto out;
+	r = usbi_sanitize_device(dev);
+	if (r < 0)
+		goto out;
+
+out:
+	if (r < 0)
+		libusb_unref_device(dev);
+	else
+		usbi_connect_device(dev);
+
+	return r;
+}
 #endif
 
 const struct usbi_os_backend linux_usbfs_backend = {
@@ -2874,6 +2961,11 @@ const struct usbi_os_backend linux_usbfs_backend = {
 	.get_config_descriptor = op_get_config_descriptor,
 	.get_config_descriptor_by_value = op_get_config_descriptor_by_value,
 
+#ifdef __ANDROID__
+	.get_device2 = op_get_device2,
+#else
+	.get_device2 = NULL,
+#endif
 	.open = op_open,
 	.close = op_close,
 	.get_configuration = op_get_configuration,

--- a/libusb/os/linux_usbfs.c
+++ b/libusb/os/linux_usbfs.c
@@ -2884,9 +2884,6 @@ int linux_enumerate_device2(struct libusb_context *ctx, uint8_t busnum, uint8_t 
 out:
 	if (r < 0)
 		libusb_unref_device(dev);
-	else
-		usbi_connect_device(dev);
-
 	return r;
 }
 #endif

--- a/libusb/os/linux_usbfs.h
+++ b/libusb/os/linux_usbfs.h
@@ -188,5 +188,6 @@ int linux_get_device_address (struct libusb_context *ctx, int detached,
 	const char *sys_name);
 int linux_enumerate_device(struct libusb_context *ctx,
 	uint8_t busnum, uint8_t devaddr, const char *sysfs_dir);
-
+int linux_enumerate_device2(struct libusb_context *ctx, uint8_t busnum, uint8_t devaddr,
+	const char* descriptors, size_t descriptors_size);
 #endif


### PR DESCRIPTION
Add `libusb_get_device2`,`libusb_open2`

On Android N, we got "permission denied" when accessing "/sys/bus/usb/devices". Here is the workaround.
1. On Java side, ask for permission and open the device. Pass the device name (use UsbDevice.getDeviceName), file descriptor (use UsbDeviceConnection.getFilesDescriptor) and raw descriptors (use UsbDeviceConnection.getRawDescriptors) down to libusb.
2. Call `libusb_get_device2` with device name and raw descriptors to get `libusb_device`.
3. Call `libusb_open2` with the libusb_device and the file descriptor.
