### PR TITLE
Fix that Ctrl Buffer of UVC_GET_CUR Is not Transferred to Host

### DIFF
--- a/libusb/sync.c
+++ b/libusb/sync.c
@@ -108,8 +108,7 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 
 	libusb_fill_control_setup(buffer, bmRequestType, bRequest, wValue, wIndex,
 		wLength);
-	if ((bmRequestType & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT)
-		memcpy(buffer + LIBUSB_CONTROL_SETUP_SIZE, data, wLength);
+	memcpy(buffer + LIBUSB_CONTROL_SETUP_SIZE, data, wLength);
 
 	libusb_fill_control_transfer(transfer, dev_handle, buffer,
 		sync_transfer_cb, &completed, timeout);


### PR DESCRIPTION
This is required to simplify transferring index to device in UVC_GET_CUR as in V4L2 and DirectShow. This will simplify refactoring of XU command for reading and writing sensor registers.